### PR TITLE
Made print() mod optional, changed to PrintToFile() in our custom code

### DIFF
--- a/Code Snippets.lua
+++ b/Code Snippets.lua
@@ -1,4 +1,20 @@
--- BASIC MENU SYSTEM --
+---- MODDING PRINT() TO SEE DEBUG MESSAGES ----
+-- Use this to make the game's debug messages print to a text file in the Journey folder. Usually it just outputs to stdout/the console, but we don't know if/how we can read the console yet. Using a program like mTail, you can view the text file updates in real time like an actual console.
+
+function print( s )
+    file = io.open("stdout.txt", "a")
+    io.output(file)
+    io.write(s.."\n")
+    file:close()
+end
+
+--Also, use either of these to see even more debug info; seems to mostly be resource loading details when levels begin. Both cause the game to print the same extra info, but might have different effects on other things in the game.
+CONFIG = "Debug"
+--or
+CONFIG = "Production"
+
+
+---- BASIC MENU SYSTEM ----
 --Only works when the normal menu is closed, since this kind of input isn't detected when that's open
 --This could all certainly be changed/improved, this is just a basic example to build from
 

--- a/StartLua.lua
+++ b/StartLua.lua
@@ -28,7 +28,7 @@ file:write(tostring(content).."\n")
 file:close()
 end
 
-function print( s, name )
+function PrintToFile( s, name )
     name = name or "stdout.txt"
     file = io.open(name, "a")
     io.output(file)
@@ -40,10 +40,13 @@ end
 
 function FunctionInfo(f)
 	for key,value in pairs(debug.getinfo(f)) do
-		print("found member " .. key.."   value:"..tostring(value), "FunctionInfo.txt")
+		PrintToFile("found member " .. key.."   value:"..tostring(value), "FunctionInfo.txt")
 	end
 end
 
+function DumpClassInfos( c )
+    local classInfos = {}
+    for name,var in pairs( c ) do
 function DumpClassInfos( c )
     local classInfos = {}
     for name,var in pairs( c ) do
@@ -52,7 +55,7 @@ function DumpClassInfos( c )
     table.sort( classInfos, function( t0, t1 ) return t0.name < t1.name end )
 
     for i,classInfo in ipairs( classInfos ) do
-        print( "KEY: "..classInfo.name.." ): "..classInfo.data, "ClassInfo.txt" )
+        PrintToFile( "KEY: "..classInfo.name.." ): "..classInfo.data, "ClassInfo.txt" )
     end
 end
 
@@ -61,10 +64,10 @@ end
 function DebugPrintError( ... )
     local sep = ""
     for i,arg in ipairs( { ... } ) do
-        print( sep..tostring( arg ), "stderr.txt" )
+        PrintToFile( sep..tostring( arg ), "stderr.txt" )
         sep = "\t"
     end
-    print( "\n", "stderr.txt" )
+    PrintToFile( "\n", "stderr.txt" )
 end
 
 function DumpMetaSys()
@@ -87,7 +90,7 @@ function SpawnEvent( eventTable )
 			return
 		end
 		
-		--useful for debug, but laggy/takes up space if spawning tons of events
+		--useful for debug, but maybe laggy/take up space if spawning tons of events and have print() going to file
 		--print( "Spawning event '"..eventType.."'" )
 		
 		local event = eventBarn:MetaAddEvent( eventType )

--- a/Useful Functions.txt
+++ b/Useful Functions.txt
@@ -5,7 +5,7 @@ DumpClassInfos(c)
   (For "c", use _G to see everything at the top level, then use the name of almost anything marked as a table to see inside of it, and to see inside deeper use TopTable.TableInside.TableDeeperInside.Etc .)
 
 CONFIG = ...
-  Changes the global variable CONFIG which shows what sort of build the game is. "Valid" options appear to be Gold, PublicBeta, Demo, Production, and Debug. Using anything other than Gold/PublicBeta/Demo will turn on DebugPrint which outputs some debug info to stdout.txt . Using Production or Debug might allow some scripts to work that are otherwise unusable, hasn't been fully explored.
+  Changes the global variable CONFIG which shows what sort of build the game is. "Valid" options appear to be Gold, PublicBeta, Demo, Production, and Debug. Using anything other than Gold/PublicBeta/Demo will turn on DebugPrint which outputs some debug info to stdout (use modified print() from Code Snippets to make it actually print to the readable file stdout.txt) . Using Production or Debug might allow some scripts to work that are otherwise unusable, hasn't been fully explored.
 
 ToggleDMActive(game)
   Toggles "Rocket Death Match" mode on and off. Chirp to shoot rockets, press fly button/key rapidly to jump. Your companion can't see your rockets/explosions/craters/etc, but they do see you moving around strangely due to the third-person-shooter controls and jumping instead of flying.


### PR DESCRIPTION
Did this so people won't have a slowly growing text file of debug messages in their Journey folder, and can just add print() mod from Code Snippets to see debug messages if they want it